### PR TITLE
Add ability to move tabs to beginning/end (and Mac keybindings)

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,6 @@
 [
     { "keys": ["ctrl+shift+pageup"], "command": "move_view", "args": {"direction": "left"} },
-    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} }
+    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} },
+    { "keys": ["ctrl+shift+home"], "command": "move_view", "args": {"direction": "beginning"} },
+    { "keys": ["ctrl+shift+end"], "command": "move_view", "args": {"direction": "end"} }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-    // Disabled (need to find out how to move tabs in Chrome/Chromium on Mac)
-    {}
+    { "keys": ["ctrl+shift+pageup"], "command": "move_view", "args": {"direction": "left"} },
+    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,6 @@
 [
     { "keys": ["ctrl+shift+pageup"], "command": "move_view", "args": {"direction": "left"} },
-    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} }
+    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} },
+    { "keys": ["ctrl+shift+home"], "command": "move_view", "args": {"direction": "beginning"} },
+    { "keys": ["ctrl+shift+end"], "command": "move_view", "args": {"direction": "end"} }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,6 @@
 [
     { "keys": ["ctrl+shift+pageup"], "command": "move_view", "args": {"direction": "left"} },
-    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} }
+    { "keys": ["ctrl+shift+pagedown"], "command": "move_view", "args": {"direction": "right"} },
+    { "keys": ["ctrl+shift+home"], "command": "move_view", "args": {"direction": "beginning"} },
+    { "keys": ["ctrl+shift+end"], "command": "move_view", "args": {"direction": "end"} }
 ]

--- a/MoveView.py
+++ b/MoveView.py
@@ -27,8 +27,14 @@ class MoveView(sublime_plugin.WindowCommand):
         elif direction == 'right':
             if index < num_views - 1:
                 index += 1
+        elif direction == 'beginning':
+            if index > 0:
+                index = 0
+        elif direction == 'end':
+            if index < num_views - 1:
+                index = num_views -1
         else:
-            print 'Unrecognized direction:', direction + '. Use left or right.'
+            print 'Unrecognized direction:', direction + '. Use left, right, beginning, or end.'
 
         # Move the view
         if target_index != index:

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Moves tabs in Sublime Text, like in Google Chrome.
 Keybindings
 -----------
 
-**There are no Mac keybindings yet!**
+The default keybindings are:
 
-If somebody knows how tabs are moved in Chrome on Mac, please let me know.
+*Ctrl+Shift+Page Up/Down* for moving tabs left/right.  
+*Ctrl+Shift+Home/End* for moving tabs to the beginning/end.
 
-The default keybindings on Linux and Windows are:
+For small Mac keyboards, use Fn+Ctrl+Shift and the arrow keys:
 
-*Ctrl+Shift+Page Up/Down* for moving tabs left/right.
+*Fn+Ctrl+Shift+Up/Down* for moving tabs left/right.  
+*Fn+Ctrl+Shift+Left/Right* for moving tabs to the beginning/end.


### PR DESCRIPTION
I've added a couple more cases to MoveView.py to move a tab all the way to the left (beginning) or the right (end). The default bindings are Ctrl+Shift+Home/End. I'm certainly open to suggestions for other defaults though—these make sense on my MacBook (since Home/End map to Fn+Left/Fn+Right), but may not be as sensible for other platforms.

I've also added default key bindings for page up and page down on OSX, which follows the convention that [this Chrome extension](https://chrome.google.com/webstore/detail/moigagbiaanpboaflikhdhgdfiifdodd) uses, and I updated the readme accordingly.
